### PR TITLE
Escape *s in the formula description

### DIFF
--- a/regression-formulas/static-intro.ipynb
+++ b/regression-formulas/static-intro.ipynb
@@ -23,7 +23,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -34,7 +33,7 @@
     "* (~) Separates the left-hand side and right-hand side of a formula. Optional. If not present, then the formula is considered to contain a right-hand side only.\n",
     "* (+) Takes the set of terms given on the left and the set of terms given on the right, and returns a set of terms that combines both (i.e., it computes a set union). Note that this means that a + a is just a.\n",
     "* (-) Takes the set of terms given on the left and removes any terms which are given on the right (i.e., it computes a set difference).\n",
-    "* (*) a * b is short-hand for a + b + a:b, and is useful for the common case of wanting to include all interactions between a set of variables while partitioning their variance between lower- and higher-order interactions. (Standard ANOVA models are of the form a * b * c * ....)\n",
+    "* (\\*) a \\* b is short-hand for a + b + a:b, and is useful for the common case of wanting to include all interactions between a set of variables while partitioning their variance between lower- and higher-order interactions. (Standard ANOVA models are of the form a \\* b \\* c \\* ....)\n",
     "\n",
     "\n",
     "# Example Dataset\n",


### PR DESCRIPTION
(GitHub was assuming these were italic formatting marks.)

Been talking with @antgonza about beefing up the Songbird docs regarding formulas, and remembered that it'd be nice to link this repo's notebooks -- this is just a minor thing I noticed going through them.